### PR TITLE
Fix incorrectly spelled occurrences of Fluentd and Fluent Bit names

### DIFF
--- a/docs/configuration/fluentbit.md
+++ b/docs/configuration/fluentbit.md
@@ -9,7 +9,7 @@ aliases:
 
 Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations.
 
-You can configure the Fluent-bit deployment via the **fluentbit** section of the {{% xref "/docs/one-eye/logging-operator/configuration/logging.md" %}}. This page shows some examples on configuring Fluent-bit. For the detailed list of available parameters, see {{% xref "/docs/one-eye/logging-operator/configuration/crds/v1beta1/fluentbit_types.md" %}}.
+You can configure the Fluent Bit deployment via the **fluentbit** section of the {{% xref "/docs/one-eye/logging-operator/configuration/logging.md" %}}. This page shows some examples on configuring Fluent Bit. For the detailed list of available parameters, see {{% xref "/docs/one-eye/logging-operator/configuration/crds/v1beta1/fluentbit_types.md" %}}.
 
 ## Filters
 
@@ -57,7 +57,7 @@ For the detailed list of available parameters for this plugin, see {{% xref "/do
 
 ## Buffering
 
-Buffering in Fluent-bit places the processed data into a temporal location until is sent to Fluentd. By default, the Logging operator sets `storage.path` to `/buffers` and leaves fluent-bit defaults for the other options.
+Buffering in Fluent Bit places the processed data into a temporal location until is sent to Fluentd. By default, the Logging operator sets `storage.path` to `/buffers` and leaves Fluent Bit defaults for the other options.
 
 ```yaml
 apiVersion: logging.banzaicloud.io/v1beta1
@@ -94,11 +94,11 @@ spec:
   controlNamespace: logging
 ```
 
-## Custom Fluent-bit image
+## Custom Fluent Bit image
 
-You can deploy custom images by overriding the default images using the following parameters in the fluentd or fluentbit sections of the logging resource.
+You can deploy custom images by overriding the default images using the following parameters in the Fluentd or fluentbit sections of the logging resource.
 
-The following example deploys a custom fluentd image:
+The following example deploys a custom Fluentd image:
 
 ```yaml
 apiVersion: logging.banzaicloud.io/v1beta1
@@ -136,7 +136,7 @@ spec:
 
 For the detailed list of available parameters for this plugin, see {{% xref "/docs/one-eye/logging-operator/configuration/crds/v1beta1/fluentbit_types.md#volumemount" %}}.
 
-## Custom Fluent-bit annotations
+## Custom Fluent Bit annotations
 
 ```yaml
 apiVersion: logging.banzaicloud.io/v1beta1

--- a/docs/configuration/logging.md
+++ b/docs/configuration/logging.md
@@ -4,10 +4,10 @@ shorttitle: Logging
 weight: 20
 ---
 
-The `logging` resource defines the logging infrastructure for your cluster that collects and transports your log messages, and also contains configurations for Fluentd and Fluent-bit. It also establishes the `controlNamespace`, the administrative namespace of the Logging operator. The Fluentd statefulset and Fluent-bit daemonset are deployed in this namespace, and global resources like `ClusterOutput` and `ClusterFlow` are evaluated only in this namespace by default - they are ignored in any other namespace unless `allowClusterResourcesFromAllNamespaces` is set to true.
+The `logging` resource defines the logging infrastructure for your cluster that collects and transports your log messages, and also contains configurations for Fluentd and Fluent Bit. It also establishes the `controlNamespace`, the administrative namespace of the Logging operator. The Fluentd statefulset and Fluent Bit daemonset are deployed in this namespace, and global resources like `ClusterOutput` and `ClusterFlow` are evaluated only in this namespace by default - they are ignored in any other namespace unless `allowClusterResourcesFromAllNamespaces` is set to true.
 
-You can define multiple `logging` resources if needed, for example, if you want to run multiple fluentd instances with separate configurations.
-You can customize the fluentd and fluent-bit configuration in the logging resource). It also declares `watchNamespaces` if applicable to narrow down the namespaces in which the logging operator should evaluate and incorporate`Flow` and `Output` resources into fluentd's configuration.
+You can define multiple `logging` resources if needed, for example, if you want to run multiple Fluentd instances with separate configurations.
+You can customize the Fluentd and Fluent Bit configuration in the logging resource). It also declares `watchNamespaces` if applicable to narrow down the namespaces in which the logging operator should evaluate and incorporate`Flow` and `Output` resources into Fluentd's configuration.
 
 You can install a `logging` resource with built-in TLS generation using the [logging Helm chart](https://github.com/banzaicloud/logging-operator/tree/master/charts/logging-operator-logging).
 
@@ -17,7 +17,7 @@ For the list of available parameters for logging resource, see {{% xref "/docs/o
 
 You can also customize the `fluentd` statefulset that Logging operator deploys. For a list of parameters, see {{% xref "/docs/one-eye/logging-operator/configuration/crds/v1beta1/fluentd_types.md" %}}. For examples on customizing the Fluentd configuration, see {{% xref "/docs/one-eye/logging-operator/configuration/fluentd.md" %}}.
 
-You can also customize the `fluent-bit` that Logging operator deploys. For a list of parameters, see {{% xref "/docs/one-eye/logging-operator/configuration/crds/v1beta1/fluentbit_types.md" %}}. For examples on customizing the Fluent-bit configuration, see {{% xref "/docs/one-eye/logging-operator/configuration/fluentbit.md" %}}.
+You can also customize the `fluent-bit` that Logging operator deploys. For a list of parameters, see {{% xref "/docs/one-eye/logging-operator/configuration/crds/v1beta1/fluentbit_types.md" %}}. For examples on customizing the Fluent Bit configuration, see {{% xref "/docs/one-eye/logging-operator/configuration/fluentbit.md" %}}.
 
 The following example snippets use the **logging** namespace. To create this namespace if it does not already exist, run:
 

--- a/docs/configuration/plugins/outputs/custom-fluentd-output.md
+++ b/docs/configuration/plugins/outputs/custom-fluentd-output.md
@@ -1,12 +1,12 @@
 ---
-title: How to add a custom FluentD output plugin to Logging operator
-shorttitle: Custom FluentD plugin
+title: How to add a custom Fluentd output plugin to Logging operator
+shorttitle: Custom Fluentd plugin
 weight: 1000
 ---
 
-If there is a FluentD plugin that the Logging operator does not support (for example, [https://github.com/cloudfoundry-community/fluent-plugin-nats](https://github.com/cloudfoundry-community/fluent-plugin-nats)), here is how you can make it work with the Logging operator. Note that this is not a detailed tutorial, just a high-level overview of the process.
+If there is a Fluentd plugin that the Logging operator does not support (for example, [https://github.com/cloudfoundry-community/fluent-plugin-nats](https://github.com/cloudfoundry-community/fluent-plugin-nats)), here is how you can make it work with the Logging operator. Note that this is not a detailed tutorial, just a high-level overview of the process.
 
-1. Add the plugin to the latest FluentD dockerfile used by the Logging operator [for example, at the moment v1.11](https://github.com/banzaicloud/logging-operator/blob/master/fluentd-image/v1.11/Dockerfile).
+1. Add the plugin to the latest Fluentd dockerfile used by the Logging operator [for example, at the moment v1.11](https://github.com/banzaicloud/logging-operator/blob/master/fluentd-image/v1.11/Dockerfile).
 1. Write the Go code to have the Output CRD support the new plugin. You can use the [Redis plugin pull request](https://github.com/banzaicloud/logging-operator/pull/549/files) as an example.
 1. Execute code and CRD generation by running `make generate manifests`
     To make sure the CI won't complain, commit your changes and run `make check-diff`

--- a/docs/configuration/tls.md
+++ b/docs/configuration/tls.md
@@ -5,18 +5,18 @@ weight: 200
 
 To use TLS encryption in your logging infrastructure, you have to configure encryption:
 
-- for the log collection part of your logging pipeline (between FLuent-bit and Fluentd), and
+- for the log collection part of your logging pipeline (between Fluent Bit and Fluentd), and
 - for the output plugin (between Fluentd and the output backend).
 
 For configuring the output, see the documentation of the output plugin you want to use at {{% xref "/docs/one-eye/logging-operator/configuration/plugins/outputs/_index.md" %}}.
 
-For Fluentd and Fluent-bit, you can configure encryption in the `logging` resource using the following parameters:
+For Fluentd and Fluent Bit, you can configure encryption in the `logging` resource using the following parameters:
 
 | Name                    | Type           | Default | Description |
 |-------------------------|----------------|---------|-------------|
 | enabled | bool | "Yes" | Enable TLS encryption |
 | secretName | string | "" | Kubernetes secret that contains: **tls.crt, tls.key, ca.crt** |
-| sharedKey | string | "" | Shared secret for fluentd authentication |
+| sharedKey | string | "" | Shared secret for Fluentd authentication |
 
 For example:
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -99,7 +99,7 @@ To document the plugins logging-operator uses the Go `tags` (like JSON tags). Lo
 
 #### Special tag `default`
 
-The default tag helps to give `default` values for parameters. These parameters are explicitly set in the generated fluentd configuration.
+The default tag helps to give `default` values for parameters. These parameters are explicitly set in the generated Fluentd configuration.
 
 ```go
 RetryForever bool `json:"retry_forever" plugin:"default:true"`

--- a/docs/headless/component-overview.md
+++ b/docs/headless/component-overview.md
@@ -2,7 +2,7 @@ You can define `outputs` (destinations where you want to send your log messages,
 
 You can configure the Logging operator using the following Custom Resource Definitions.
 
-- [logging]({{< relref "docs/one-eye/logging-operator/configuration/logging.md" >}}) - The `logging` resource defines the logging infrastructure for your cluster that collects and transports your log messages. It also contains configurations for Fluentd and Fluent-bit.
+- [logging]({{< relref "docs/one-eye/logging-operator/configuration/logging.md" >}}) - The `logging` resource defines the logging infrastructure for your cluster that collects and transports your log messages. It also contains configurations for Fluentd and Fluent Bit.
 - [output]({{< relref "docs/one-eye/logging-operator/configuration/output.md" >}}) - Defines an Output for a logging flow, where the log messages are sent. This is a namespaced resource. See also `clusteroutput`.
 - [flow]({{< relref "docs/one-eye/logging-operator/configuration/flow.md" >}}) - Defines a logging flow using `filters` and `outputs`. Basically, the flow routes the selected log messages to the specified outputs. This is a namespaced resource. See also `clusterflow`.
 - [clusteroutput]({{< relref "docs/one-eye/logging-operator/configuration/output.md" >}}) - Defines an output that is available from all flows and clusterflows. The operator evaluates clusteroutputs in the `controlNamespace` only unless `allowClusterResourcesFromAllNamespaces` is set to true.

--- a/docs/operation/logging-operator-monitoring.md
+++ b/docs/operation/logging-operator-monitoring.md
@@ -10,7 +10,7 @@ aliases:
 
 <p align="center"><img src="../../img/monitor.png" width="900"></p>
 
-You can configure the Logging operator to expose metrics endpoints for FluentD and Fluent-bit using ServiceMonitor resources. That way, a Prometheus operator running in the same cluster can automatically fetch your logging metrics.
+You can configure the Logging operator to expose metrics endpoints for Fluentd and Fluent Bit using ServiceMonitor resources. That way, a [Prometheus operator](https://github.com/coreos/prometheus-operator) running in the same cluster can automatically fetch your logging metrics.
 
 ## Metrics Variables
 

--- a/docs/operation/troubleshooting/fluentd.md
+++ b/docs/operation/troubleshooting/fluentd.md
@@ -114,7 +114,7 @@ The following command displays the logs of the Fluentd container.
 
 > The [One Eye](/products/one-eye/) observability tool can [display Fluentd logs on its web UI](/docs/one-eye/troubleshooting/), where you can select which replica to inspect, search the logs, and use other ways to monitor and troubleshoot your logging infrastructure.
 
-> Tip: If the logs include the `error="can't create buffer file ...` error message, FluentD can’t create the buffer file at the specified location. This can mean for example that the disk is full, the filesystem is read-only, or some other permission error. Check the buffer-related settings of your [Fluentd configuration](/docs/one-eye/logging-operator/configuration/fluentd/).
+> Tip: If the logs include the `error="can't create buffer file ...` error message, Fluentd can’t create the buffer file at the specified location. This can mean for example that the disk is full, the filesystem is read-only, or some other permission error. Check the buffer-related settings of your [Fluentd configuration](/docs/one-eye/logging-operator/configuration/fluentd/).
 
 ## Set stdout as an output
 


### PR DESCRIPTION
It's Fluentd and Fluent Bit, not FluentD, Fluent-bit, and so on.