### PR TITLE
Adds a red border to caution blocks

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,0 +1,12 @@
+/*
+
+Nothing defined here. The Hugo project that uses this theme can override Bootstrap by adding a file to:
+
+assets/scss/_styles_project.scss
+
+*/
+.warning-block {
+    border-left: 6px solid red;
+    background: #FFFFFF;
+    padding: 16px;
+  }


### PR DESCRIPTION
Warning/Caution blocks are not styled properly, so you cannot see where the block ends and where the normal text begins.