### PR TITLE
Adds trailing slash to production baseurl

### DIFF
--- a/config/production/config.toml
+++ b/config/production/config.toml
@@ -1,4 +1,4 @@
-baseurl = "https://kube-logging.github.io"
+baseurl = "https://kube-logging.github.io/"
 buildDrafts = false
 #googleAnalytics = "G-FIXME"
 
@@ -9,4 +9,4 @@ buildDrafts = false
 
 [params]
 
-url_latest_version = "https://kube-logging.github.io"
+url_latest_version = "https://kube-logging.github.io/"


### PR DESCRIPTION
Because it plays tricks with out include-code shortcode