### PR TITLE
fix: use the correct field names in the monitoring example

### DIFF
--- a/content/docs/operation/logging-operator-monitoring.md
+++ b/content/docs/operation/logging-operator-monitoring.md
@@ -14,7 +14,7 @@ You can configure the Logging operator to expose metrics endpoints for Fluentd, 
 
 ## Metrics Variables
 
-You can configure the following metrics-related options in the **fluentdSpec**, **syslogNGSpec**, and **fluentbitSpec** sections of your Logging resource.
+You can configure the following metrics-related options in the **spec.fluentd.metrics**, **spec.syslogNG.metrics**, and **spec.fluentbit.metrics** sections of your Logging resource.
 
 | Variable Name | Type | Required | Default | Description |
 |---|---|---|---|---|

--- a/content/docs/operation/logging-operator-monitoring.md
+++ b/content/docs/operation/logging-operator-monitoring.md
@@ -29,13 +29,13 @@ For example:
 
 ```yaml
 spec:
-  fluentdSpec:
+  fluentd:
     metrics:
       serviceMonitor: true
-  fluentbitSpec:
+  fluentbit:
     metrics:
       serviceMonitor: true
-  syslogNGSpec:
+  syslogNG:
     metrics:
       serviceMonitor: true
 ```


### PR DESCRIPTION
The field types are `fluentdSpec`, `fluentbitSpec` etc. However the field _names_ are just `fluentd`, `fluentbit` etc.