### PR TITLE
Update fluent-bit link in image-versions.md

### DIFF
--- a/content/docs/image-versions.md
+++ b/content/docs/image-versions.md
@@ -15,7 +15,7 @@ Logging operator uses the following image versions.
 | k8s.gcr.io/pause |  | 3.2 |
 | docker.io/busybox | https://github.com/docker-library/busybox | latest |
 | ghcr.io/axoflow/axosyslog | https://github.com/axoflow/axosyslog-docker/ | 4.5.0 |
-| docker.io/fluent/fluent-bit | https://github.com/fluent/fluent-bit-docker-image | 2.1.8 |
+| docker.io/fluent/fluent-bit | https://github.com/fluent/fluent-bit | 2.1.8 |
 | ghcr.io/kube-logging/fluentd | https://github.com/kube-logging/fluentd-images | v1.16-full |
 | ghcr.io/axoflow/axosyslog-metrics-exporter | https://github.com/axoflow/axosyslog-metrics-exporter | 0.0.2 |
 | ghcr.io/kube-logging/syslogng-reload | https://github.com/kube-logging/syslogng-reload-image | v1.3.1 |


### PR DESCRIPTION
the old url links to an archived git repo