### PR TITLE
chore(ci): update node-version to v18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-main.yaml
+++ b/.github/workflows/publish-main.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-version-4.0.yaml
+++ b/.github/workflows/publish-version-4.0.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-version-4.2.yaml
+++ b/.github/workflows/publish-version-4.2.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-version-4.3.yaml
+++ b/.github/workflows/publish-version-4.3.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-version-4.4.yaml
+++ b/.github/workflows/publish-version-4.4.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-version.yaml
+++ b/.github/workflows/publish-version.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
A [currently made PR](https://github.com/kube-logging/kube-logging.github.io/pull/225) shows that currently the CI is broken:
```
hugo v0.110.0-e32a493b7826d02763c3b79623952e625402b168+extended linux/amd64 BuildDate=2023-01-17T12:16:09Z VendorInfo=gohugoio
Error: Error building site: POSTCSS: failed to transform "scss/main.css" (text/css): file:///home/runner/work/kube-logging.github.io/kube-logging.github.io/node_modules/@sindresorhus/merge-streams/index.js:2
Total in 2905 ms
import {PassThrough as PassThroughStream, getDefaultHighWaterMark} from 'node:stream';
                                          ^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: The requested module 'node:stream' does not provide an export named 'getDefaultHighWaterMark'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:123:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:189:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:530:24)
    at async loadESM (node:internal/process/esm_loader:91:5)
    at async handleMainPromise (node:internal/modules/run_main:[6](https://github.com/kube-logging/kube-logging.github.io/actions/runs/7901445427/job/21565614632?pr=225#step:7:7)5:[12](https://github.com/kube-logging/kube-logging.github.io/actions/runs/7901445427/job/21565614632?pr=225#step:7:13))
npm notice
```
Let's see if a node-version upgrades fixes it.