### PR TITLE
Google analytics 4 (GA4): configure CNCF ID

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -276,3 +276,7 @@ anchor = "smart"
 [privacy]
   [privacy.googleAnalytics]
     respectDoNotTrack = true
+
+[services]
+  [services.googleAnalytics]
+    id = 'G-LM8C8QXCN7'


### PR DESCRIPTION
- Contributes to CNCF service desk request [Google Analytics setup for the Logging Operator documentation site CNCFSD-2325](https://cncfservicedesk.atlassian.net/browse/CNCFSD-2325)

/cc @nate-double-u