### PR TITLE
Don't show announcement bar if there are no announcements to show

### DIFF
--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,10 +1,10 @@
 {{ if .Params.show_banner -}}
   {{ $announcements := site.GetPage "announcements" -}}
   {{ if $announcements -}}
+    {{ range $announcements.RegularPages }}
     <div class="menu-banner">
-      {{ range $announcements.RegularPages }}
       <div>{{ .Content }}</div>
-      {{ end -}}
     </div>
+    {{ end -}}
   {{ end -}}
 {{ end -}}


### PR DESCRIPTION
Needed because the kubecon banner expired and would be empty after the next build.
