### PR TITLE
chore: standardize naming to "Logging operator"

### DIFF
--- a/assets/icons/logo.svg
+++ b/assets/icons/logo.svg
@@ -79,7 +79,7 @@
     </g>
     <text
        id="Logging_Operator"
-       data-name="Logging Operator"
+       data-name="Logging operator"
        transform="translate(45475.035 34799.609)"
        fill="#fff"
        font-size="267"
@@ -88,6 +88,6 @@
        letter-spacing="0.046em"><tspan
          x="-1339.806"
          y="0"
-         id="tspan138">Logging Operator</tspan></text>
+         id="tspan138">Logging operator</tspan></text>
   </g>
 </svg>

--- a/content/docs/configuration/plugins/outputs/kafka.md
+++ b/content/docs/configuration/plugins/outputs/kafka.md
@@ -10,7 +10,7 @@ generated_file: true
 
 For details, see [https://github.com/fluent/fluent-plugin-kafka](https://github.com/fluent/fluent-plugin-kafka).
 
-For an example deployment, see [Transport Nginx Access Logs into Kafka with Logging Operator](../../../../quickstarts/kafka-nginx/).
+For an example deployment, see [Transport Nginx Access Logs into Kafka with Logging operator](../../../../quickstarts/kafka-nginx/).
 
 ## Example output configurations
 

--- a/content/docs/configuration/plugins/outputs/loki.md
+++ b/content/docs/configuration/plugins/outputs/loki.md
@@ -9,7 +9,7 @@ generated_file: true
 
 Fluentd output plugin to ship logs to a Loki server. For details, see [https://grafana.com/docs/loki/latest/clients/fluentd/](https://grafana.com/docs/loki/latest/clients/fluentd/).
 
-For a detailed example, see [Store Nginx Access Logs in Grafana Loki with Logging Operator](../../../../quickstarts/loki-nginx/).
+For a detailed example, see [Store Nginx Access Logs in Grafana Loki with Logging operator](../../../../quickstarts/loki-nginx/).
 
 ## Example output configurations
 

--- a/content/docs/configuration/plugins/outputs/relabel.md
+++ b/content/docs/configuration/plugins/outputs/relabel.md
@@ -4,7 +4,7 @@ weight: 200
 generated_file: true
 ---
 
-Available in Logging Operator version 4.2 and later.
+Available in Logging operator version 4.2 and later.
 
 The relabel output uses the [relabel output plugin of Fluentd](https://docs.fluentd.org/output/relabel) to route events back to a specific Flow, where they can be processed again.
 

--- a/content/docs/examples/cloudwatch-nginx.md
+++ b/content/docs/examples/cloudwatch-nginx.md
@@ -1,5 +1,5 @@
 ---
-title: Store Nginx Access Logs in Amazon CloudWatch with Logging Operator
+title: Store Nginx Access Logs in Amazon CloudWatch with Logging operator
 linktitle: Amazon CloudWatch with Fluentd
 weight: 100
 aliases:

--- a/content/docs/examples/sumologic.md
+++ b/content/docs/examples/sumologic.md
@@ -6,7 +6,7 @@ aliases:
     - /docs/one-eye/logging-operator/quickstarts/sumologic/
 ---
 
-This guide walks you through a simple Sumo Logic setup using the Logging Operator.
+This guide walks you through a simple Sumo Logic setup using the Logging operator.
 Sumo Logic has Prometheus and logging capabilities as well. Now we only focus on the logging part.
 
 ## Configuration

--- a/content/docs/operation/logging-operator-monitoring.md
+++ b/content/docs/operation/logging-operator-monitoring.md
@@ -74,7 +74,7 @@ For more details on installing the Prometheus operator and configuring and acces
     > The logging-operator metrics function depends on the prometheus-operator's resources.
     > If those do not exist in the cluster it may cause the logging-operator's malfunction.
 
-## Install Logging Operator with Helm
+## Install Logging operator with Helm
 
 1. {{< include-headless "helm-install-logging-operator.md" >}}
 

--- a/content/docs/operation/scaling.md
+++ b/content/docs/operation/scaling.md
@@ -11,7 +11,7 @@ aliases:
 
 In a large-scale infrastructure the logging components can get high load as well. The typical sign of this is when `fluentd` cannot handle its [buffer](../../configuration/plugins/outputs/buffer/) directory size growth for more than the configured or calculated (timekey + timekey_wait) flush interval. In this case, you can [scale the fluentd statefulset]({{< relref "../logging-infrastructure/fluentd.md#scaling" >}}).
 
-The Logging Operator supports scaling a **Fluentd aggregator** statefulset up and down. Scaling statefulset pods down is challenging, because we need to take care of the underlying volumes with buffered data that hasn't been sent, but the Logging Operator supports that use case as well.
+The Logging operator supports scaling a **Fluentd aggregator** statefulset up and down. Scaling statefulset pods down is challenging, because we need to take care of the underlying volumes with buffered data that hasn't been sent, but the Logging operator supports that use case as well.
 
 The details for that and how to configure an HPA is described in the following documents:
 - https://github.com/kube-logging/logging-operator/blob/master/docs/volume-drainer.md

--- a/content/docs/operation/troubleshooting/_index.md
+++ b/content/docs/operation/troubleshooting/_index.md
@@ -34,7 +34,7 @@ The following tips and commands can help you to troubleshoot your Logging operat
     logging-demo-log-generator-6448d45cd9-z7zk8   1/1     Running     0          24m
     ```
 
-1. Check the status of your resources. Beginning with Logging Operator 3.8, all custom resources have a `Status` and a `Problems` field. In a healthy system, the Problems field of the resources is empty, for example:
+1. Check the status of your resources. Beginning with Logging operator 3.8, all custom resources have a `Status` and a `Problems` field. In a healthy system, the Problems field of the resources is empty, for example:
 
     ```bash
     kubectl get clusteroutput -A

--- a/content/docs/quickstarts/_index.md
+++ b/content/docs/quickstarts/_index.md
@@ -3,6 +3,6 @@ title: Quick start guides
 weight: 200
 ---
 
-Try out Logging Operator with these quick start guides, that show you the basics of Logging operator.
+Try out Logging operator with these quick start guides, that show you the basics of Logging operator.
 
 For other detailed examples using different outputs, see {{% xref "docs/examples/_index.md" %}}.


### PR DESCRIPTION
Followup https://github.com/kube-logging/logging-operator/issues/1986